### PR TITLE
Update go SDK

### DIFF
--- a/docs/api-sdk.md
+++ b/docs/api-sdk.md
@@ -23,7 +23,8 @@ on this repository.
 
 ## Go
 
-- [zilean](https://github.com/GincoInc/zillean)
+- ~~[zilean](https://github.com/GincoInc/zillean)~~
+- [LaksaGo](https://github.com/FireStack-Lab/LaksaGo)
 
 ## Ruby
 

--- a/docs/api-sdk.md
+++ b/docs/api-sdk.md
@@ -23,7 +23,7 @@ on this repository.
 
 ## Go
 
-- ~~[zilean](https://github.com/GincoInc/zillean)~~
+- ~~[zilean](https://github.com/GincoInc/zillean) (Discontinued)~~
 - [LaksaGo](https://github.com/FireStack-Lab/LaksaGo)
 
 ## Ruby


### PR DESCRIPTION
Strikeout legacy GO SDK and add current GO SDK, `LaksaGo`