### PR TITLE
Fix link to WebSocket service inside staking docs

### DIFF
--- a/docs/staking/phase0/staking-getting-started.md
+++ b/docs/staking/phase0/staking-getting-started.md
@@ -18,13 +18,13 @@ description: Staking Getting Started
 It is necessary for the staked seed node to be whitelisted by Zilliqa in phase 0 in order to receive data broadcasts about the blockchain and its state. This requires a static public IP address with minimal the following inbound and outbound port open.
 
 
-| Type     | Default  | Purpose                                        |
-|----------|--------- | ---------------------------------------------- |
-| Inbound  | 33133    | Protocol level port for receiving network data |
+| Type     | Default  | Purpose                                                  |
+|----------|--------- | -------------------------------------------------------- |
+| Inbound  | 33133    | Protocol level port for receiving network data           |
 | Inbound  | 4201/443 | [API service](https://apidocs.zilliqa.com/#introduction) |
-| Inbound  | 4401     | [Websocket servuce](api-websocket)             |
-| Inbound  | 4501     | Staking API service                            |
-| Outbound | 443      | For getting initial node data for syncing      |
+| Inbound  | 4401     | [WebSocket service](../../dev/dev-tools-websockets)      |
+| Inbound  | 4501     | Staking API service                                      |
+| Outbound | 443      | For getting initial node data for syncing                |
 
 ## Preparing the Node
 

--- a/docs/staking/phase1/ssn-operator/staking-ssn-setup.mdx
+++ b/docs/staking/phase1/ssn-operator/staking-ssn-setup.mdx
@@ -16,13 +16,13 @@ import TabItem from '@theme/TabItem';
 
 ## Default Port Requirements for SSNs
 
-| Type     | Default  | Purpose                                        |
-|----------|--------- | ---------------------------------------------- |
-| Inbound  | 33133    | Protocol level port for receiving network data |
+| Type     | Default  | Purpose                                                  |
+|----------|--------- | -------------------------------------------------------- |
+| Inbound  | 33133    | Protocol level port for receiving network data           |
 | Inbound  | 4201/443 | [API service](https://apidocs.zilliqa.com/#introduction) |
-| Inbound  | 4401     | [Websocket service](api-websocket)             |
-| Inbound  | 4501     | Staking API service                            |
-| Outbound | 443      | For getting initial node data for syncing      |
+| Inbound  | 4401     | [WebSocket service](../../../dev/dev-tools-websockets)   |
+| Inbound  | 4501     | Staking API service                                      |
+| Outbound | 443      | For getting initial node data for syncing                |
 
 ## Preparing the Node
 


### PR DESCRIPTION
Looks like this link wasn't defined correctly even in the earlier layout (where we had Staking under Exchange).
Pointing it now to the WebSocket server doc inside Dev section.