### PR TITLE
Change base OS name to Ubuntu 18.04 in documentation

### DIFF
--- a/docs/contributors/contribute-buildzil.md
+++ b/docs/contributors/contribute-buildzil.md
@@ -16,7 +16,7 @@ While we have made great strides to realize the core protocol that runs the Zill
 
 ## Quickstart Guide
 
-Building the Zilliqa code base is officially supported only on Ubuntu 16.04.
+Building the Zilliqa code base is officially supported on Ubuntu 18.04.
 
 Follow these steps to perform the build:
 

--- a/docs/exchanges/exchange-getting-started.md
+++ b/docs/exchanges/exchange-getting-started.md
@@ -37,7 +37,7 @@ Please contact us for more information on setting up a seed node with this schem
 :::
 
 ## Minimum Hardware Requirements
-- x64 Linux operating system (e.g Ubuntu 16.04.05)
+- x64 Linux operating system (e.g Ubuntu 18.04.5)
 - Recent dual core processor @ 2.2 GHZ. Examples:
    - Intel Core i5 or i7 (Skylake)
    - Intel Xeon (Skylake)
@@ -90,7 +90,7 @@ $ ./launch_docker.sh --genkeypair
 ### Native Setup
 
 :::note
-This approach has only been tested on **Ubuntu 16.04** and involves compiling
+This approach has been tested on **Ubuntu 18.04** and involves compiling
 C++. We strongly recommend you consider using the Docker image provided above.
 :::
 

--- a/docs/miners/mining-zilclient.md
+++ b/docs/miners/mining-zilclient.md
@@ -12,11 +12,11 @@ description: Running the Zilliqa Client Mining
 ---
 ## Hardware Requirements
 
-The [**Zilliqa Client**](https://github.com/Zilliqa/zilliqa) is only officially supported on Ubuntu 16.04 OS.
+The [**Zilliqa Client**](https://github.com/Zilliqa/zilliqa) is officially supported on Ubuntu 18.04 OS.
 
 The **minimum** requirements for running the **Zilliqa Client** are:
 
-- x64 Linux operating system (e.g Ubuntu 16.04.05)
+- x64 Linux operating system (e.g Ubuntu 18.04.5)
 - Recent dual-core processor @ 2.2 GHZ. Examples:
    - Intel Core i5 or i7 (Skylake)
    - Intel Xeon (Skylake)
@@ -61,7 +61,7 @@ The first message means UPnP mode has been enabled successfully, while the latte
 
 ## Mining Steps
 
-1. Create a single local or remote CPU node instance with Ubuntu 16.04 OS installed following instructions [**HERE**](http://releases.ubuntu.com/xenial/).
+1. Create a single local or remote CPU node instance with Ubuntu 18.04 OS installed following instructions [**HERE**](http://releases.ubuntu.com/xenial/).
 
 2. Install Docker CE for Ubuntu on your CPU node instance by following instructions [**HERE**](https://docs.docker.com/install/linux/docker-ce/ubuntu/).
 

--- a/docs/staking/phase0/staking-getting-started.md
+++ b/docs/staking/phase0/staking-getting-started.md
@@ -87,7 +87,7 @@ We highly recommend to use another keypair for depositing stake, withdrawing sta
 ### Launching the Node Using Native Build
 
 :::caution
-This approach has only been tested on `Ubuntu 16.04.6 LTS` and involves compiling and building the `C++` codebase from scratch. We strongly recommend you consider launching the node using the Docker steps detailed in the previous section.
+This approach has been tested on `Ubuntu 18.04.5 LTS` and involves compiling and building the `C++` codebase from scratch. We strongly recommend you consider launching the node using the Docker steps detailed in the previous section.
 :::
 
 If you cannot or do not wish to use Docker, you may also build the Zilliqa binary from the source and run it as such.


### PR DESCRIPTION
## Description

The PR changes the documentation part to reference `Ubuntu 18.04` instead of `Ubuntu 16.04` as base OS for Zilliqa nodes.