### PR TITLE
Add ssn-configuration.tar.gz for staking operators

### DIFF
--- a/docs/staking/phase1/ssn-operator/staking-ssn-setup.mdx
+++ b/docs/staking/phase1/ssn-operator/staking-ssn-setup.mdx
@@ -68,9 +68,9 @@ Once you have set up Docker, you may proceed to download and uncompress the conf
 # create a directory
 $ mkdir my_seed && cd my_seed
 
-# download and extract the seed node configuration files
-$ wget https://testnet-join.zilliqa.com/seed-configuration.tar.gz
-$ tar -zxvf seed-configuration.tar.gz
+# download and extract the SSN configuration files
+$ wget https://testnet-join.zilliqa.com/ssn-configuration.tar.gz
+$ tar -zxvf ssn-configuration.tar.gz
 ```
 
 </TabItem>
@@ -80,17 +80,16 @@ $ tar -zxvf seed-configuration.tar.gz
 # create a directory
 $ mkdir my_seed && cd my_seed
 
-# download and extract the seed node configuration files
-$ wget https://mainnet-join.zilliqa.com/seed-configuration.tar.gz
-$ tar -zxvf seed-configuration.tar.gz
+# download and extract the SSN configuration files
+$ wget https://mainnet-join.zilliqa.com/ssn-configuration.tar.gz
+$ tar -zxvf ssn-configuration.tar.gz
 ```
 
 </TabItem>
 </Tabs>
 
-The seed node requires some configuring before it can successfully join the network and be used for staking. Most configuration is contained in `constants.xml`, which should be in the directory you extracted seed-configuration.tar.gz to. Minimally, the following changes are required:
+The seed node requires some configuring before it can successfully join the network and be used for staking. Most configuration is contained in `constants.xml`, which should be in the directory you extracted ssn-configuration.tar.gz to. Minimally, the following changes are required:
 
-- Change the value of `ENABLE_STAKING_RPC` to `true`
 - **Optional:** Change the value of `SEED_PORT` to `33133` (default), or a port of your choice. If you do not select `33133`, be sure to note this down for the subsequent whitelisting step.
   :::caution Important notice 
   If you have used a port other than 33133, and have opted for IP-based whitelisting, please notify us immediately so that we can adjust our whitelisted port for you.
@@ -152,9 +151,9 @@ The build should complete with no errors. Once it is done, download and uncompre
 # create a directory
 $ mkdir my_seed && cd my_seed
 
-# download and extract the seed node configuration files
-$ wget https://testnet-join.zilliqa.com/seed-configuration.tar.gz
-$ tar -zxvf seed-configuration.tar.gz
+# download and extract the SSN configuration files
+$ wget https://testnet-join.zilliqa.com/ssn-configuration.tar.gz
+$ tar -zxvf ssn-configuration.tar.gz
 ```
 
 </TabItem>
@@ -164,17 +163,16 @@ $ tar -zxvf seed-configuration.tar.gz
 # create a directory
 $ mkdir my_seed && cd my_seed
 
-# download and extract the seed node configuration files
-$ wget https://mainnet-join.zilliqa.com/seed-configuration.tar.gz
-$ tar -zxvf seed-configuration.tar.gz
+# download and extract the SSN configuration files
+$ wget https://mainnet-join.zilliqa.com/ssn-configuration.tar.gz
+$ tar -zxvf ssn-configuration.tar.gz
 ```
 
 </TabItem>
 </Tabs>
 
-The staked seed node requires some configuring before it can successfully join the network and be used for staking. Most configuration is contained in `constants.xml`, which should be in the directory you extracted `configuration.tar.gz` to. Minimally, the following changes are required:
+The staked seed node requires some configuring before it can successfully join the network and be used for staking. Most configuration is contained in `constants.xml`, which should be in the directory you extracted `ssn-configuration.tar.gz` to. Minimally, the following changes are required:
 
-- Change the value of `ENABLE_STAKING_RPC` to `true`
 - **Optional:** Change the value of `SEED_PORT` to `33133` (default), or a port of your choice. If you do not select `33133`, be sure to note this down for the subsequent whitelisting step.
   :::caution Important notice 
   If you have used a port other than 33133, and have opted for IP-based whitelisting, please notify us immediately so that we can adjust our whitelisted port for you.


### PR DESCRIPTION
I've already retrofitted both mainnet and testnet to include `ssn-configuration.tar.gz`.

With this new config SSN operators won't need to manually change `ENABLE_STAKING_RPC` anymore (which many usually forget to do).