### PR TITLE
Remove links to GetPendingTxn and GetPendingTxns sections

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -35,8 +35,6 @@ module.exports = {
     "apis/api-transaction-get-minimum-gas-price",
     "apis/api-transaction-get-num-txns-dsepoch",
     "apis/api-transaction-get-num-txns-txepoch",
-    "apis/api-transaction-get-pending-tx",
-    "apis/api-transaction-get-pending-txs",
     "apis/api-transaction-get-recent-txs",
     "apis/api-transaction-get-tx",
     "apis/api-transaction-get-transaction-status",


### PR DESCRIPTION
For v8.0.0 we have removed `GetPendingTxn` and will temporarily disable `GetPendingTxns` due to performance issues.
So I've removed the links to these 2 sections in the apidocs.
The actual docs are still there in case we want to bring them back in the future.