### PR TITLE
feat: remove kyc requirement

### DIFF
--- a/docs/exchanges/exchange-ip-whitelisting.md
+++ b/docs/exchanges/exchange-ip-whitelisting.md
@@ -18,7 +18,6 @@ Before you start, please ensure the steps below are done.
 1. Choose and note down a port you wish to reserve for your seed node to receive incoming blockchain data.
 1. Share the static IP address and port of the node with the Zilliqa support team for whitelisting.
    This step is critical, as failing to provide the correct IP and port will result in failure to receive blockchain data.
-   The static IP address and port of choice have to be shared with the Zilliqa team in the KYC form.
 
 :::important
 The port of choice must be opened to inbound connections. Otherwise, the seed node will be unreachable.
@@ -136,10 +135,6 @@ following changes are required:
 
 ## Joining the Network
 
-:::note
-Before proceeding with this step, make sure you have completed the necessary KYC (for an individual).
-:::
-
 Once the preliminary steps have been completed, joining the network is relatively
 straightforward.
 
@@ -152,8 +147,7 @@ $ ./launch.sh
 ```
 
 You will be asked a series of questions. When asked to enter your IP address
-and listening port, please enter the values you provided us when you submitted
-the KYC form. This is crucial, as your node **will not work** with anything
+and listening port. This is crucial, as your node **will not work** with anything
 else.
 
 Sample instructions to be followed for launch are provided below.

--- a/docs/exchanges/exchange-key-whitelisting-1.md
+++ b/docs/exchanges/exchange-key-whitelisting-1.md
@@ -57,7 +57,6 @@ $ sudo docker run --rm zilliqa/zilliqa:<version> -c genkeypair
 ```
 
 The first value from the ouput is the public key and second value is the private key.
-The public key has to be shared in advance while submitting the KYC form.
 The private key is required to start the seed node.
 
 :::info
@@ -156,10 +155,6 @@ following changes are required:
 
 ## Joining the Network
 
-:::note
-Before proceeding with this step, make sure you have completed the necessary KYC (for individual).
-:::
-
 Once the preliminary steps have been completed, joining the network is relatively
 straightforward.
 
@@ -173,8 +168,7 @@ $ ./launch.sh
 
 You will be asked a series of questions.
 When asked to enter your listening port, please enter the value you noted down earlier.
-When asked to enter the private key, please enter the value you provided us when you submitted
-the KYC form. This is crucial, as your node **will not work** with anything else.
+When asked to enter the private key. This is crucial, as your node **will not work** with anything else.
 
 Sample instructions to be followed for launch are provided below.
 

--- a/docs/exchanges/exchange-key-whitelisting-2.md
+++ b/docs/exchanges/exchange-key-whitelisting-2.md
@@ -49,7 +49,6 @@ $ sudo docker run --rm zilliqa/zilliqa:<version> -c genkeypair
 ```
 
 The first value from the ouput is the public key and second value is the private key.
-The public key has to be shared in advance while submitting the KYC form.
 The private key is required to start the seed node.
 
 :::info
@@ -148,10 +147,6 @@ following changes are required:
 
 ## Joining the Network
 
-:::note
-Before proceeding with this step, make sure you have completed the necessary KYC (for individual).
-:::
-
 Once the preliminary steps have been completed, joining the network is relatively
 straightforward.
 
@@ -164,8 +159,8 @@ $ ./launch.sh
 ```
 
 You will be asked a series of questions.
-When asked to enter the private key, please enter the value you provided us when you submitted
-the KYC form. This is crucial, as your node **will not work** with anything else.
+When asked to enter the private key, please enter the value you provided to us 
+This is crucial, as your node **will not work** with anything else.
 
 Sample instructions to be followed for launch are provided below.
 


### PR DESCRIPTION
There is no need to KYC seed node. As such, removing the legacy text