### PR TITLE
chore: add cname to static folder

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+dev.zilliqa.com


### PR DESCRIPTION
For easy deployment and no need to recreate cname everything we redeploy