### PR TITLE
Updated seed and SSN launching pages

### DIFF
--- a/docs/exchanges/exchange-ip-whitelisting.md
+++ b/docs/exchanges/exchange-ip-whitelisting.md
@@ -173,6 +173,34 @@ Enter your listening port (default: 33133): <33133 or other selected port>
 Use IP whitelisting registration approach (default: Y): Y
 ```
 
+## Testing Your Seed Node's JSON-RPC Port
+
+To check whether your node's JSON-RPC server is publicly available, you can use the following curl command.
+
+```bash
+curl -d '{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "method": "GetBlockchainInfo",
+    "params": [""]
+}' -H "Content-Type: application/json" -X POST "<seed node address>"
+```
+
+If you received the latest blockchain information (similar to the one below) from the seed node, your JSON-RPC service is running well.
+
+```bash
+{"id":"1","jsonrpc":"2.0","result":{"CurrentDSEpoch":"4789","CurrentMiniEpoch":"478809","DSBlockRate":0.00013455546527607284,"NumDSBlocks":"4790","NumPeers":2400,"NumTransactions":"3091806","NumTxBlocks":"478809","NumTxnsDSEpoch":"185","NumTxnsTxEpoch":"0","ShardingStructure":{"NumPeers":[600,600,600]},"TransactionRate":0,"TxBlockRate":0.013450003515398927}}
+```
+
+## Testing Your Seed Node's WebSocket Port
+
+You can use an online WebSocket test utility to test whether your WebSocket is publicly accessible.
+
+1. Visit https://www.websocket.org/echo.html
+1. Under location, put your WebSocket URL link (e.g., `wss://<yourdomain here or ip:port>`)
+1. Click on connect
+1. If **“CONNECTED”** is shown in the log, your WebSocket port is publicly accessible
+
 ## Next Steps
 
 If you have successfully completed the above steps, you should have

--- a/docs/exchanges/exchange-key-whitelisting-1.md
+++ b/docs/exchanges/exchange-key-whitelisting-1.md
@@ -195,6 +195,34 @@ Use IP whitelisting registration approach (default: Y): N
 Enter the private key (32-byte hex string) to be used by this node and whitelisted by upper seeds: <private key generated for key whitelisting>
 ```
 
+## Testing Your Seed Node's JSON-RPC Port
+
+To check whether your node's JSON-RPC server is publicly available, you can use the following curl command.
+
+```bash
+curl -d '{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "method": "GetBlockchainInfo",
+    "params": [""]
+}' -H "Content-Type: application/json" -X POST "<seed node address>"
+```
+
+If you received the latest blockchain information (similar to the one below) from the seed node, your JSON-RPC service is running well.
+
+```bash
+{"id":"1","jsonrpc":"2.0","result":{"CurrentDSEpoch":"4789","CurrentMiniEpoch":"478809","DSBlockRate":0.00013455546527607284,"NumDSBlocks":"4790","NumPeers":2400,"NumTransactions":"3091806","NumTxBlocks":"478809","NumTxnsDSEpoch":"185","NumTxnsTxEpoch":"0","ShardingStructure":{"NumPeers":[600,600,600]},"TransactionRate":0,"TxBlockRate":0.013450003515398927}}
+```
+
+## Testing Your Seed Node's WebSocket Port
+
+You can use an online WebSocket test utility to test whether your WebSocket is publicly accessible.
+
+1. Visit https://www.websocket.org/echo.html
+1. Under location, put your WebSocket URL link (e.g., `wss://<yourdomain here or ip:port>`)
+1. Click on connect
+1. If **“CONNECTED”** is shown in the log, your WebSocket port is publicly accessible
+
 ## Next Steps
 
 If you have successfully completed the above steps, you should have

--- a/docs/exchanges/exchange-key-whitelisting-2.md
+++ b/docs/exchanges/exchange-key-whitelisting-2.md
@@ -183,6 +183,34 @@ Enter your IP address ('NAT' or *.*.*.*): <static ip address>
 Enter the private key (32-byte hex string) to be used by this node and whitelisted by upper seeds: <private key generated for key whitelisting>
 ```
 
+## Testing Your Seed Node's JSON-RPC Port
+
+To check whether your node's JSON-RPC server is publicly available, you can use the following curl command.
+
+```bash
+curl -d '{
+    "id": "1",
+    "jsonrpc": "2.0",
+    "method": "GetBlockchainInfo",
+    "params": [""]
+}' -H "Content-Type: application/json" -X POST "<seed node address>"
+```
+
+If you received the latest blockchain information (similar to the one below) from the seed node, your JSON-RPC service is running well.
+
+```bash
+{"id":"1","jsonrpc":"2.0","result":{"CurrentDSEpoch":"4789","CurrentMiniEpoch":"478809","DSBlockRate":0.00013455546527607284,"NumDSBlocks":"4790","NumPeers":2400,"NumTransactions":"3091806","NumTxBlocks":"478809","NumTxnsDSEpoch":"185","NumTxnsTxEpoch":"0","ShardingStructure":{"NumPeers":[600,600,600]},"TransactionRate":0,"TxBlockRate":0.013450003515398927}}
+```
+
+## Testing Your Seed Node's WebSocket Port
+
+You can use an online WebSocket test utility to test whether your WebSocket is publicly accessible.
+
+1. Visit https://www.websocket.org/echo.html
+1. Under location, put your WebSocket URL link (e.g., `wss://<yourdomain here or ip:port>`)
+1. Click on connect
+1. If **“CONNECTED”** is shown in the log, your WebSocket port is publicly accessible
+
 ## Next Steps
 
 If you have successfully completed the above steps, you should have

--- a/docs/staking/phase1/ssn-operator/staking-ssn-setup.mdx
+++ b/docs/staking/phase1/ssn-operator/staking-ssn-setup.mdx
@@ -15,272 +15,47 @@ description: Setting up the SSN
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::info
+The Mainnet has been upgraded to support staking phase 1.1. You can now start to run a staked seed node on the Mainnet.
+:::
+
 ## Default Port Requirements for SSNs
+
+Before preparing to host an SSN, please note that these are the ports that **must** be enabled in the SSN:
 
 | Type     | Default  | Purpose                                                  |
 | -------- | -------- | -------------------------------------------------------- |
 | Inbound  | 33133    | Protocol level port for receiving network data           |
 | Inbound  | 4201/443 | [API service](https://apidocs.zilliqa.com/#introduction) |
-| Inbound  | 4401     | [WebSocket service](../../../dev/dev-tools-websockets)   |
 | Inbound  | 4501     | Staking API service                                      |
 | Outbound | 443      | For getting initial node data for syncing                |
 
+Additionally, there are ports that **may** be enabled in the SSN:
+
+| Type     | Default  | Purpose                                                  |
+| -------- | -------- | -------------------------------------------------------- |
+| Inbound  | 4401     | [WebSocket service](../../../dev/dev-tools-websockets)   |
+
 ## Preparing the Node
 
-:::info
-Mainnet has been upgraded to support staking phase 1. You can now start to run a staked seed node on mainnet.
-Smart contract enrollment will happen 1-2 days before staking phase 1 launch.
-:::
+Launching a seed node for staking is similar to launching a normal seed node using [key whitelisting mode (option 1)](../../../exchanges/exchange-key-whitelisting-1), with some additional configuration steps.
 
-Launching a seed node for staking is similar to launching a normal seed node, with some additional configuration steps.
-
-In this guide, we will walk you through the steps on how to set up the seed node via
-
-1. Docker
-1. Native build
-
-You can go for either one of the options below (click to expand).
-
-<Tabs
-  defaultValue="docker"
-  values={[
-    { label: 'Docker', value: 'docker', },
-    { label: 'Native Build', value: 'manual', },
-  ]
-}>
-<TabItem value="docker">
-
-### Launching the Node Using Docker
-
-We highly recommend using [Docker](https://docker.com/) to set up a seed node, as we provide a tested, production-ready image for your use. If you have not yet set up Docker, please follow the instructions on the [official documentation](https://docs.docker.com/install/).
-
-Once you have set up Docker, you may proceed to download and uncompress the configuration tarball for the Mainnet:
-
-<Tabs
-  defaultValue="testnet"
-  values={[
-    { label: 'Testnet', value: 'testnet', },
-    { label: 'Mainnet', value: 'mainnet', }
-  ]
-}>
-<TabItem value="testnet">
-
-```bash
-# create a directory
-$ mkdir my_seed && cd my_seed
-
-# download and extract the SSN configuration files
-$ wget https://testnet-join.zilliqa.com/ssn-configuration.tar.gz
-$ tar -zxvf ssn-configuration.tar.gz
-```
-
-</TabItem>
-<TabItem value="mainnet">
-
-```bash
-# create a directory
-$ mkdir my_seed && cd my_seed
-
-# download and extract the SSN configuration files
-$ wget https://mainnet-join.zilliqa.com/ssn-configuration.tar.gz
-$ tar -zxvf ssn-configuration.tar.gz
-```
-
-</TabItem>
-</Tabs>
-
-The seed node requires some configuring before it can successfully join the network and be used for staking. Most configuration is contained in `constants.xml`, which should be in the directory you extracted ssn-configuration.tar.gz to. Minimally, the following changes are required:
-
-- **Optional:** Change the value of `SEED_PORT` to `33133` (default), or a port of your choice. If you do not select `33133`, be sure to note this down for the subsequent whitelisting step.
-  :::caution Important notice
-  If you have used a port other than 33133, and have opted for IP-based whitelisting, please notify us immediately so that we can adjust our whitelisted port for you.
-  :::
-- **Optional:** Change the value of `ENABLE_WEBSOCKET` to `true` if your seed node will support WebSockets (refer to the [Zilliqa Websocket Server](../../../dev/dev-tools-websockets) documentation).
-
-Finally, launch the seed node:
-
-```
-$ ./launch_docker.sh
-```
-
-:::info
-A seed node needs a key pair to communicate with other nodes in the network. launch_docker.sh will automatically generate and use a key pair stored in the file mykey.txt in the same folder.
-:::
+1. First, please verify that your SSN meets the [minimum hardware requirements](../../../exchanges/exchange-getting-started#minimum-hardware-requirements).
+1. Follow the steps for launching a seed node using [key whitelisting mode (option 1)](../../../exchanges/exchange-key-whitelisting-1), except use `ssn-configuration.tar.gz` instead of `seed-configuration.tar.gz`.
 
 :::caution
-We highly recommend to use another keypair for depositing stake, withdrawing stake and withdrawing reward.
+Step 2 above includes generating a key pair for launching the seed node. We highly recommend **not** to use the same key pair for depositing stake, withdrawing stake and withdrawing reward.
 :::
-
-</TabItem>
-<TabItem value="manual">
-
-### Launching the Node Using Native Build
-
-If you cannot or do not wish to use Docker, you may also build the Zilliqa binary from the source and run it as such.
-
-:::caution
-This approach has only been tested on `Ubuntu 18.04.5 LTS` and involves compiling and building the `C++` codebase from scratch. We strongly recommend you consider launching the node using the Docker steps detailed in the other tab.
-:::
-
-First, clone the Zilliqa repository:
-
-```bash
-# clone Zilliqa source files
-$ git clone https://github.com/Zilliqa/Zilliqa.git && cd Zilliqa && git checkout <<release tag>> && cd Zilliqa
-```
-
-Install system dependencies:
-
-```bash
-# install system dependencies
-$ sudo apt-get update && sudo apt-get install \
-    git \
-    libboost-system-dev \
-    libboost-filesystem-dev \
-    libboost-test-dev \
-    libssl-dev \
-    libleveldb-dev \
-    libjsoncpp-dev \
-    libsnappy-dev \
-    cmake \
-    libmicrohttpd-dev \
-    libjsonrpccpp-dev \
-    build-essential \
-    pkg-config \
-    libevent-dev \
-    libminiupnpc-dev \
-    libcurl4-openssl-dev \
-    libboost-program-options-dev \
-    libboost-python-dev \
-    python3-dev         \
-    python3-setuptools  \
-    python3-pip         \
-    gawk
-
-$ sudo apt install python-pip
-$ export LC_ALL=C
-$ pip install request requests clint futures
-$ pip3 install requests clint futures
-```
-
-Build the staked seed node:
-
-```bash
-# Build the binary. This may take a while.
-$ ./build.sh
-```
-
-The build should complete with no errors. Once it is done, download and uncompress the configuration tarball:
-
-You will also need to build Scilla. Build instruction can be found [here](https://github.com/Zilliqa/scilla#building-scilla).
-
-<Tabs
-  defaultValue="testnet"
-  values={[
-    { label: 'Testnet', value: 'testnet', },
-    { label: 'Mainnet', value: 'mainnet', }
-  ]
-}>
-<TabItem value="testnet">
-
-```bash
-# create a directory
-$ mkdir my_seed && cd my_seed
-
-# download and extract the SSN configuration files
-$ wget https://testnet-join.zilliqa.com/ssn-configuration.tar.gz
-$ tar -zxvf ssn-configuration.tar.gz
-```
-
-</TabItem>
-<TabItem value="mainnet">
-
-```bash
-# create a directory
-$ mkdir my_seed && cd my_seed
-
-# download and extract the SSN configuration files
-$ wget https://mainnet-join.zilliqa.com/ssn-configuration.tar.gz
-$ tar -zxvf ssn-configuration.tar.gz
-```
-
-</TabItem>
-</Tabs>
-
-The staked seed node requires some configuring before it can successfully join the network and be used for staking. Most configuration is contained in `constants.xml`, which should be in the directory you extracted `ssn-configuration.tar.gz` to. Minimally, the following changes are required:
-
-- **Optional:** Change the value of `SEED_PORT` to `33133` (default), or a port of your choice. If you do not select `33133`, be sure to note this down for the subsequent whitelisting step.
-  :::caution Important notice
-  If you have used a port other than 33133, and have opted for IP-based whitelisting, please notify us immediately so that we can adjust our whitelisted port for you.
-  :::
-- Change the value of `ENABLE_WEBSOCKET` to `true` if your seed node will support WebSockets (refer to the [Zilliqa Websocket Server](../../../dev/dev-tools-websockets) documentation).
-
-Finally, launch the seed node:
-
-```bash
-$ ./launch.sh
-```
-
-:::info
-A seed node needs a key pair to communicate with other nodes in the network. launch.sh will automatically generate and use a key pair stored in the file mykey.txt in the same folder
-:::
-
-:::caution
-We highly recommend to use another keypair for depositing stake, withdrawing stake and withdrawing reward.
-:::
-
-</TabItem>
-</Tabs>
 
 ### Configuring Domain Name
 
 Once your seed node is fully set up, it is time to configure your domain name to point to the address of your seed node.
-
-If your seed node is not behind a load balancer, you can set an `A record` in your domain registrar to point your domain/subdomain to your seed node’s IP address.
-
-If your seed node is behind a load balancer, you can set a `CNAME record` in your domain registrar to point your domain/subdomain to the hostname of your load balancer.
+- If your seed node is not behind a load balancer, you can set an `A record` in your domain registrar to point your domain/subdomain to your seed node’s IP address.
+- If your seed node is behind a load balancer, you can set a `CNAME record` in your domain registrar to point your domain/subdomain to the hostname of your load balancer.
 
 ### SSL/TLS Configuration
 
 As the staked seed nodes are for public consumption, we expect these nodes to have high availability and be secure and reliable. As such, all operators are required to support serving of API and raw data requests over SSL/TLS.
-
-## Whitelisting and API Servicing
-
-It is necessary for the staked seed node to be whitelisted by Zilliqa in phase 1 in order to receive data broadcasts about the blockchain and its state.
-Currently, there are 2 forms of whitelisting supported:
-
-1. Whitelisting via a static IP
-1. Whitelisting via public key of the SSN
-
-We recommend SSN operators to use the whitelisting by public key approach.
-
-### Testing Your SSN's JSON-RPC Port
-
-To check whether your node's JSON-RPC server is publicly available, you can use the following curl command.
-
-```bash
-curl -d '{
-    "id": "1",
-    "jsonrpc": "2.0",
-    "method": "GetBlockchainInfo",
-    "params": [""]
-}' -H "Content-Type: application/json" -X POST "<staked seed node address>"
-```
-
-If you received the latest blockchain information (similar to the one below) from the staked seed node, your JSON-RPC service is running well.
-
-```bash
-{"id":"1","jsonrpc":"2.0","result":{"CurrentDSEpoch":"4789","CurrentMiniEpoch":"478809","DSBlockRate":0.00013455546527607284,"NumDSBlocks":"4790","NumPeers":2400,"NumTransactions":"3091806","NumTxBlocks":"478809","NumTxnsDSEpoch":"185","NumTxnsTxEpoch":"0","ShardingStructure":{"NumPeers":[600,600,600]},"TransactionRate":0,"TxBlockRate":0.013450003515398927}}
-```
-
-### Testing Your SSN's WebSocket Port
-
-You can use an online WebSocket test utility to test whether your WebSocket is publicly accessible.
-
-1. Visit https://www.websocket.org/echo.html
-1. Under location, put your WebSocket URL link (e.g., `wss://<yourdomain here or ip:port>`)
-1. Click on connect
-1. If **“CONNECTED”** is shown in the log, your WebSocket port is publicly accessible
 
 ## Advanced Setup
 


### PR DESCRIPTION
The current [SSN launching instructions](https://dev.zilliqa.com/docs/staking/phase1/ssn-operator/staking-ssn-setup) page is a bit confusing because it allows picking a whitelist option to use, when in fact `ssn-configuration.tar.gz` is configured for key whitelist option 1.

Also, seed launch details are written verbatim in the SSN launching instructions page, and these are a bit outdated compared to the ones in the Exchanges section.

Instead of writing the details verbatim, I changed the SSN launching instructions page to just simply refer to the [key whitelisting option 1](https://dev.zilliqa.com/docs/exchanges/exchange-key-whitelisting-1) page.

Also, the SSN page had some steps for checking the API and websocket. I decided to move these steps into the exchange sections instead (in all 3 whitelist modes).